### PR TITLE
fix nginx configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ server {
     }
 
     location / {
-        proxy_pass 127.0.0.1:8080;
+        proxy_pass http://127.0.0.1:8080;
     }
 }
 
@@ -73,7 +73,7 @@ server {
     server_name doc.local;
 
     location ~ ^/([^/]+)/([^/]+)/pages/(.*)$ {
-        proxy_pass 127.0.0.1:8080;
+        proxy_pass http://127.0.0.1:8080;
     }
 
     location / {


### PR DESCRIPTION
sample has invalid URL

```
# /etc/init.d/nginx reload
nginx: [emerg] invalid URL prefix in /etc/nginx/nginx.conf:149
nginx: configuration file /etc/nginx/nginx.conf test failed
```
