### PR TITLE
Bump to Scalatra 2.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ site generators ([jekyll](http://jekyllrb.com/), [hugo](https://gohugo.io/), etc
 
 | pages version | gitbucket version |
 |     :---:     |       :---:       |
+| 1.6.0         | 4.19.0            |
+| 1.5.0         | 4.15.0            |
 | 1.3           | 4.14.1            |
 | 1.2           | 4.13              |
 | 1.1           | 4.11              |

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 organization  := "gitbucket"
 name          := "gitbucket-pages-plugin"
-scalaVersion  := "2.12.2"
+scalaVersion  := "2.12.4"
 scalacOptions := Seq("-unchecked", "-deprecation", "-encoding", "utf8", "-feature")
 
 enablePlugins(SbtTwirl)

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ resolvers ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "io.github.gitbucket"   %%  "gitbucket"           % "4.15.0",
+  "io.github.gitbucket"   %%  "gitbucket"           % "4.19.0",
   "javax.servlet"         %   "javax.servlet-api"   % "3.1.0"
 )
 

--- a/src/main/scala/gitbucket/plugin/pages/pages.scala
+++ b/src/main/scala/gitbucket/plugin/pages/pages.scala
@@ -8,7 +8,7 @@ import gitbucket.core.util.{ Directory, JGitUtil, OwnerAuthenticator, ReferrerAu
 import gitbucket.pages.html
 import gitbucket.plugin.model.PageSourceType
 import gitbucket.plugin.service.PagesService
-import io.github.gitbucket.scalatra.forms._
+import org.scalatra.forms._
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.lib.ObjectId
 import org.eclipse.jgit.revwalk.RevCommit


### PR DESCRIPTION
GitBucket's [scalatra-forms](https://github.com/gitbucket/scalatra-forms) has been merged in Scalatra 2.6 and GitBucket uses it since 4.19.0. So bundled plugins have to update following it to release GitBucket 4.19.0.