### PR TITLE
Fix warning

### DIFF
--- a/src/main/scala/gitbucket/plugin/model/Pages.scala
+++ b/src/main/scala/gitbucket/plugin/model/Pages.scala
@@ -3,7 +3,7 @@ package gitbucket.plugin.model
 trait PagesComponent { self: gitbucket.core.model.Profile =>
   import profile.api._
 
-  implicit val psColumnType =
+  implicit val psColumnType: BaseColumnType[PageSourceType] =
     MappedColumnType.base[PageSourceType, String](ps => ps.code, code => PageSourceType.valueOf(code))
 
   lazy val Pages = TableQuery[Pages]


### PR DESCRIPTION
```
[warn] /home/runner/work/gitbucket-pages-plugin/gitbucket-pages-plugin/src/main/scala/gitbucket/plugin/model/Pages.scala:6:16: Implicit definition should have explicit type (inferred PagesComponent.this.profile.BaseColumnType[gitbucket.plugin.model.PageSourceType]) [quickfixable]
[warn]   implicit val psColumnType =
[warn]                ^
[warn] one warning found
```